### PR TITLE
Fixed issue where killer variable is undefined

### DIFF
--- a/Packs/Skyblock/scripts/skyblock.js
+++ b/Packs/Skyblock/scripts/skyblock.js
@@ -61,7 +61,7 @@ world.afterEvents.entityDie.subscribe((event) => {//handles on death
 	else{
 		if(typeof event.damageSource !== "undefined"){
 			let killer = event.damageSource.damagingEntity//gets the player who killed the entity
-			if (killer.typeId  == "minecraft:player"){//if the damage source was a player
+			if (killer && killer.typeId  == "minecraft:player"){//if the damage source was a player
 				world.scoreboard.getObjective("Kill Counter").addScore(killer,1)//add to kill counter
 			}
 		}


### PR DESCRIPTION
Fixed issue where killer variable is undefined.
I think this happens when a mob dies without player interaction. Encountered this a couple of times on BDS.

BDS Log:
[Check Error] > Error Found in BDS Output: [[2024-07-09 12:15:11:365 ERROR] [Scripting] TypeError: cannot read property 'typeId' of undefined    at <anonymous> (skyblock.js:64)